### PR TITLE
Allow configuration of key Carbon ports

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ graphite_api_carbon: yes                    # Install and setup Graphite Carbon
 graphite_api_carbon_udp: no                 # Enable Carbon UDP listener
 graphite_api_carbon_udp_address: 0.0.0.0    # Listen address
 graphite_api_carbon_udp_port: 2003          # Listen port
+graphite_api_carbon_line_port: 2003
+graphite_api_carbon_pickle_port: 2004
+graphite_api_carbon_cache_query_port: 7002
 
 # Setup Graphite-Whisper
 graphite_api_whisper: yes

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,6 +17,9 @@ graphite_api_carbon: yes                            # Install and setup Graphite
 graphite_api_carbon_udp: no                         # Enable Carbon UDP listener
 graphite_api_carbon_udp_address: 0.0.0.0            # Listen address
 graphite_api_carbon_udp_port: 2003                  # Listen port
+graphite_api_carbon_line_port: 2003
+graphite_api_carbon_pickle_port: 2004
+graphite_api_carbon_cache_query_port: 7002
 graphite_api_carbon_max_cache_size: inf
 graphite_api_carbon_max_updates_per_second: 500
 graphite_api_carbon_max_creates_per_minute: 50

--- a/templates/carbon.conf.j2
+++ b/templates/carbon.conf.j2
@@ -72,7 +72,7 @@ MAX_UPDATES_PER_SECOND = {{ graphite_api_carbon_max_updates_per_second }}
 MAX_CREATES_PER_MINUTE = {{ graphite_api_carbon_max_creates_per_minute }}
 
 LINE_RECEIVER_INTERFACE = 0.0.0.0
-LINE_RECEIVER_PORT = 2003
+LINE_RECEIVER_PORT = {{ graphite_api_carbon_line_port }}
 
 # Set this to True to enable the UDP listener. By default this is off
 # because it is very common to run multiple carbon daemons and managing
@@ -82,7 +82,7 @@ UDP_RECEIVER_INTERFACE = {{ graphite_api_carbon_udp_address }}
 UDP_RECEIVER_PORT = {{ graphite_api_carbon_udp_port }}
 
 PICKLE_RECEIVER_INTERFACE = 0.0.0.0
-PICKLE_RECEIVER_PORT = 2004
+PICKLE_RECEIVER_PORT = {{ graphite_api_carbon_pickle_port }}
 
 # Set to false to disable logging of successful connections
 LOG_LISTENER_CONNECTIONS = True
@@ -93,7 +93,7 @@ LOG_LISTENER_CONNECTIONS = True
 USE_INSECURE_UNPICKLER = False
 
 CACHE_QUERY_INTERFACE = 0.0.0.0
-CACHE_QUERY_PORT = 7002
+CACHE_QUERY_PORT = {{ graphite_api_carbon_cache_query_port }}
 
 # Set this to False to drop datapoints received after the cache
 # reaches MAX_CACHE_SIZE. If this is True (the default) then sockets


### PR DESCRIPTION
This means you can run more than one instance of Carbon on a single machine.
